### PR TITLE
Fix: Correct satellite setting method in GGA sentence

### DIFF
--- a/nmea-simulator-final-tested/nmea-simulator/simulator/generators/scenario_generator.py
+++ b/nmea-simulator-final-tested/nmea-simulator/simulator/generators/scenario_generator.py
@@ -293,7 +293,7 @@ class CompleteScenarioGenerator:
         gga.set_time(NMEATime.from_datetime(current_time))
         gga.set_position(nav.position.latitude, nav.position.longitude)
         gga.set_fix_quality(1)  # GPS fix
-        gga.set_satellites_used(8)
+        gga.set_satellites_in_use(8)
         gga.set_hdop(1.2)
         gga.set_altitude(0.0)
         gga.set_geoid_height(19.6)


### PR DESCRIPTION
This commit corrects an AttributeError that occurred after previous fixes to the scenario generator.

The `_generate_gps_sentences` method in `scenario_generator.py` was attempting to call `gga.set_satellites_used()`, but the correct method name in the `GGASentence` class is
`set_satellites_in_use()`.

This has been corrected to use the proper method name.