### PR TITLE
Fix: Correct TypeError and parameter types for RMCSentence

### DIFF
--- a/nmea-simulator-final-tested/nmea-simulator/nmea_lib/sentences/rmc.py
+++ b/nmea-simulator-final-tested/nmea-simulator/nmea_lib/sentences/rmc.py
@@ -206,23 +206,37 @@ class RMCSentence(PositionSentence, TimeSentence, DateSentence):
         """Get time in HHMMSS.SSS format."""
         return self._time.to_nmea() if self._time else None
     
-    def set_time(self, time_str: str) -> None:
-        """Set time in HHMMSS.SSS format."""
-        if time_str:
-            self._time = NMEATime.from_nmea(time_str)
-        else:
+    def set_time(self, time_input: any) -> None:
+        """Set time from NMEATime object or HHMMSS.SSS string."""
+        if isinstance(time_input, NMEATime):
+            self._time = time_input
+        elif isinstance(time_input, str):
+            if time_input:
+                self._time = NMEATime.from_nmea(time_input)
+            else:
+                self._time = None
+        elif time_input is None:
             self._time = None
-    
+        else:
+            raise TypeError(f"Unsupported type for time_input: {type(time_input)}. Expected str or NMEATime.")
+
     def get_date(self) -> Optional[str]:
         """Get date in DDMMYY format."""
         return self._date.to_nmea() if self._date else None
-    
-    def set_date(self, date_str: str) -> None:
-        """Set date in DDMMYY format."""
-        if date_str:
-            self._date = NMEADate.from_nmea(date_str)
-        else:
+
+    def set_date(self, date_input: any) -> None:
+        """Set date from NMEADate object or DDMMYY string."""
+        if isinstance(date_input, NMEADate):
+            self._date = date_input
+        elif isinstance(date_input, str):
+            if date_input:
+                self._date = NMEADate.from_nmea(date_input)
+            else:
+                self._date = None
+        elif date_input is None:
             self._date = None
+        else:
+            raise TypeError(f"Unsupported type for date_input: {type(date_input)}. Expected str or NMEADate.")
     
     def get_latitude(self) -> Optional[float]:
         """Get latitude in decimal degrees."""

--- a/nmea-simulator-final-tested/nmea-simulator/simulator/generators/scenario_generator.py
+++ b/nmea-simulator-final-tested/nmea-simulator/simulator/generators/scenario_generator.py
@@ -14,7 +14,8 @@ from nmea_lib.sentences.aivdm import AISMessageGenerator
 from nmea_lib.sentences.gga import GGASentence
 from nmea_lib.sentences.rmc import RMCSentence
 from nmea_lib.types import NMEATime, NMEADate
-from nmea_lib.types.units import Distance, DistanceUnit
+from nmea_lib.types.units import Distance, DistanceUnit, Speed, SpeedUnit, Bearing, BearingType
+from nmea_lib.types.enums import DataStatus
 from simulator.generators.vessel import EnhancedVesselGenerator
 
 
@@ -303,12 +304,12 @@ class CompleteScenarioGenerator:
         # RMC sentence
         rmc = RMCSentence()
         rmc.set_time(NMEATime.from_datetime(current_time))
-        rmc.set_status('A')  # Active
+        rmc.set_status(DataStatus.ACTIVE)
         rmc.set_position(nav.position.latitude, nav.position.longitude)
-        rmc.set_speed(nav.sog)
-        rmc.set_course(nav.cog)
+        rmc.set_speed(Speed(nav.sog, SpeedUnit.KNOTS))
+        rmc.set_course(Bearing(nav.cog, BearingType.TRUE))
         rmc.set_date(NMEADate.from_datetime(current_time))
-        rmc.set_magnetic_variation(0.0, 'E')
+        rmc.set_magnetic_variation(0.0)  # East variation is positive or zero
         sentences.append(str(rmc))
         
         return sentences


### PR DESCRIPTION
This commit resolves a TypeError in `RMCSentence.set_time` and proactively corrects parameter types for other RMC setters when called from `scenario_generator.py`.

Corrections include:
- Updated `RMCSentence.set_time` and `RMCSentence.set_date` to accept NMEATime/NMEADate objects directly or string inputs, similar to the GGASentence fix. This resolves the primary TypeError.
- Corrected calls in `_generate_gps_sentences` of `scenario_generator.py`:
  - `set_status` now uses the `DataStatus.ACTIVE` enum member.
  - `set_speed` now passes a `Speed` object.
  - `set_course` now passes a `Bearing` object.
  - `set_magnetic_variation` is now called with the correct single float argument.
- Added necessary imports for `DataStatus`, `Speed`, `SpeedUnit`, `Bearing`, and `BearingType` to `scenario_generator.py`.

These changes ensure that `RMCSentence` methods are called with the appropriate parameter types, resolving the reported TypeError and preventing further type mismatches during RMC sentence creation.